### PR TITLE
Update deprecated RaisedButton to ElevatedButton

### DIFF
--- a/lib/src/info_page.dart
+++ b/lib/src/info_page.dart
@@ -99,11 +99,7 @@ class InfoPage extends StatelessWidget {
       margin: const EdgeInsets.only(top: 24.0),
       alignment: Alignment.center,
       child: SizedBox.expand(
-        child: RaisedButton(
-          textTheme: Theme.of(context).buttonTheme.textTheme,
-          shape:
-              RoundedRectangleBorder(borderRadius: BorderRadius.circular(30.0)),
-          padding: const EdgeInsets.all(8),
+        child: ElevatedButton(
           child: Text(text),
           onPressed: () => _launchURL(url),
         ),


### PR DESCRIPTION
RaisedButton is removed in Flutter 3.3, so we need to migrate to ElevatedButton. Not sure how to apply the same theming though yet. Need to have some fixes for CachedNetworkImage, so made a very quick PR.