### PR TITLE
Add GitHub PR- and issue templates

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: Baseflow
+custom: https://baseflow.com/contact

--- a/.github/ISSUE_TEMPLATE/a-regression.yml
+++ b/.github/ISSUE_TEMPLATE/a-regression.yml
@@ -1,0 +1,108 @@
+name: Submit a regression
+description: You encountered unexpected behavior that worked in a previous version of the plugin.
+title: "[Regression]: "
+labels: ["needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to submit a regression!
+        To effectively tackle it, we require as much information as possible. This will allow us to quickly get to the root of the regression.
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue for this?
+      description: Please search to see if an issue already exists for this regression.
+      options:
+        - label: I have searched the [existing issues](https://github.com/baseflow/baseflow_plugin_template/issues).
+          required: true
+  - type: checkboxes
+    attributes:
+      label: Please select affected platform(s)
+      options:
+      - label: Android
+      - label: iOS
+      - label: Linux
+      - label: macOS
+      - label: Web
+      - label: Windows
+  - type: textarea
+    attributes:
+      label: Old behavior
+      description: |
+        Please provide a brief and precise description of the functionality that the Baseflow plugin template plugin had before the regression occurred.
+        Understanding the previous capabilities will assist us in pinpointing the changes and addressing the regression effectively.
+        
+        Consider attaching something showing the old behavior:
+         * code samples
+         * images
+         * videos
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Current behavior
+      description: |
+        Please provide a brief and precise description of the functionality that the Baseflow plugin template plugin has now.
+        Understanding the current capabilities will assist us in pinpointing the changes and addressing the regression effectively.
+        
+        Please attach something showing the current behavior:
+         * code samples
+         * images
+         * videos
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Steps to reproduce
+      description: Please provide specific steps to reproduce the situation in which the regression manifests.
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Code sample
+      description: |
+        Please create a minimal reproducible sample that shows the regression
+        and attach it below between the lines with the backticks.
+        
+        IMPORTANT: Please do not upload screenshots of text. Instead, use code blocks
+        or the above mentioned ways to upload your code sample.
+      value: |
+        <details><summary>Code sample</summary>
+
+        ```dart
+        [Paste your code here]
+        ```
+
+        </details>
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Screenshots or video
+      description: |
+        Please consider uploading any relevant screenshots or videos showcasing the regression, if available. These visual aids can greatly assist us in understanding and addressing the issue more effectively.
+      value: |
+        <details>
+        <summary>Screenshots or video demonstration</summary>
+
+        [Upload media here]
+
+        </details>
+  - type: input
+    attributes:
+      label: Current version
+      description: Please specify which version of the plugin are you currently using.
+      placeholder: ex. 1.2.3
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: Last version without regression
+      description: Please specify the version of the plugin in which the regression was not yet present.
+      placeholder: ex. 1.2.2
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/b-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/b-bug-report.yml
@@ -1,0 +1,105 @@
+name: Report a bug
+description: You encountered a bug in the Baseflow plugin template plugin resulting in application crashes, compilation errors or invalid/unexpected results.
+title: "[Bug]: "
+labels: ["needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to submit an issue!
+        To effectively tackle it, we require as much information as possible. This might seem a lot of information but 
+        will allow us to quickly help you and resolve the issue you are facing.
+  - type: checkboxes
+    attributes:
+      label: Please check the following before submitting a new issue.
+      options:
+      - label: I have searched the [existing issues](https://github.com/baseflow/baseflow_plugin_template/issues).
+      - label: I have carefully [read the documentation](https://github.com/Baseflow/baseflow_plugin_template/blob/master/README.md) and verified I have added the required platform specific configuration.
+        required: true
+  - type: checkboxes
+    attributes:
+      label: Please select affected platform(s)
+      options:
+      - label: Android
+      - label: iOS
+      - label: Linux
+      - label: macOS
+      - label: Web
+      - label: Windows
+  - type: textarea
+    attributes:
+      label: Steps to reproduce
+      description: Please provide specific steps to reproduce the issue.
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Expected results
+      description: Please provide a description of the expected behavior.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Actual results
+      description: Please provide a description of the current behavior.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Code sample
+      description: |
+        Please create a minimal reproducible sample that shows the problem
+        and attach it below between the lines with the backticks.
+        
+        IMPORTANT: Please do not upload screenshots of text. Instead, use code blocks
+        or the above mentioned ways to upload your code sample.
+      value: |
+        <details><summary>Code sample</summary>
+
+        ```dart
+        [Paste your code here]
+        ```
+
+        </details>
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Screenshots or video
+      description: |
+        Please consider uploading any relevant screenshots or videos showcasing the regression, if available.
+        These visual aids can greatly assist us in understanding and addressing the issue more effectively.
+      value: |
+        <details>
+        <summary>Screenshots or video demonstration</summary>
+
+        [Upload media here]
+
+        </details>
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Please specify in which version of the plugin the bug occurs.
+      placeholder: ex. 1.2.3
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Flutter Doctor output
+      description: |
+        Please provide the full output of running `flutter doctor -v`.
+      value: |
+        <details><summary>Doctor output</summary>
+
+        ```console
+        [Paste your output here]
+        ```
+
+        </details>
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/c-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/c-feature-request.yml
@@ -1,0 +1,69 @@
+name: Submit a feature request
+description: We value your input! If you have any ideas or suggestions for new features, we encourage you to share them here.
+title: "[Feature request]: "
+labels: ["needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for submitting a feature request! To help us better understand your request, kindly take a moment to provide the following information. Your input is greatly appreciated.
+
+        - Description of the feature request.
+        - Use case or problem it solves.
+        - Any specific requirements or considerations.
+        - Any additional information or context.
+
+        Thank you for your cooperation!
+  - type: checkboxes
+    attributes:
+      label: Is there already an issue requesting this feature?
+      description: Please search to see if an issue already exists for this feature request.
+      options:
+        - label: I have searched the [existing issues](https://github.com/baseflow/baseflow_plugin_template/issues).
+          required: true
+  - type: checkboxes
+    attributes:
+      label: Please select affected platform(s)
+      options:
+      - label: Android
+      - label: iOS
+      - label: Linux
+      - label: macOS
+      - label: Web
+      - label: Windows
+  - type: textarea
+    attributes:
+      label: Use case
+      description: |
+        We appreciate your feature request!
+        In order to better understand your needs, please provide details regarding the problem you're encountering that prompted your desire for a new feature.
+
+        Is your feature request driven by a specific problem?
+        Kindly provide a clear and concise description of the issue at hand.
+
+        Additionally, please share any alternative solutions you have considered.
+        Have you explored existing packages on pub.dev that might already address this problem?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Proposal
+      description: |
+        Please provide a brief and precise description of the functionality that you are proposing.
+
+        Please attach something showing what you are imagining:
+         * code samples
+         * images
+         * videos
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Specific requirements or considerations
+      description: |
+        Please provide any specific requirements or considerations that you have for this feature request.
+  - type: textarea
+    attributes:
+      label: Additional information or context
+      description: |
+        Please provide any additional information or context that you have for this feature request. Also links pointing to existing (native) APIs or articles are extremely helpful.

--- a/.github/ISSUE_TEMPLATE/d-enhancement-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/d-enhancement-proposal.yml
@@ -1,0 +1,50 @@
+name: Submit an enhancement proposal
+description: You have a proposal for code cleanup, a refactor, or other improvements.
+title: "[Enhancement proposal]: "
+labels: ["needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to submit an enhancement proposal!
+        Please take the time to fill out the information below so that we can better evaluate the need for the enhancement.
+  - type: checkboxes
+    attributes:
+      label: Please check the following before submitting a new issue.
+      options:
+        - label: I have searched the [existing issues](https://github.com/baseflow/baseflow_plugin_template/issues).
+          required: true
+        - label: I have carefully [read the documentation](https://github.com/baseflow/baseflow_plugin_template/blob/master/README.md) and verified I have added the required platform specific configuration.
+          required: true
+  - type: checkboxes
+    attributes:
+      label: Please select affected platform(s)
+      options:
+      - label: Android
+      - label: iOS
+      - label: Linux
+      - label: macOS
+      - label: Web
+      - label: Windows
+  - type: textarea
+    attributes:
+      label: Proposal
+      description: |
+        Please provide a clear and concise description of your proposed enhancement.
+
+        Please attach something showcasing your idea:
+         * code samples
+         * images
+         * videos
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Pitch
+      description: |
+        How will this refactor enhance the lives of contributors?
+        We would greatly appreciate it if you could provide us with as many details as possible.
+        Specifically, please describe the specific benefits, improvements, or advantages that contributors can expect to experience as a result of this refactor.
+        Your comprehensive input will help us better understand the impact and value of implementing this change.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/e-question.yml
+++ b/.github/ISSUE_TEMPLATE/e-question.yml
@@ -1,0 +1,48 @@
+name: Ask for help
+description: You have a question about the Baseflow plugin template plugin and are looking for help.
+title: "[Question]: "
+labels: ["needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        We are happy to help you out!
+        To help you effectively, we require some information. This will allow us to quickly understand your question.
+  - type: checkboxes
+    attributes:
+      label: Please check the following before submitting a new issue.
+      options:
+        - label: I have searched the [existing issues](https://github.com/baseflow/baseflow_plugin_template/issues).
+          required: true
+        - label: I have carefully [read the documentation](https://github.com/baseflow/baseflow_plugin_template/blob/master/README.md).
+          required: true
+  - type: checkboxes
+    attributes:
+      label: Please select for which platform(s) you need help
+      options:
+      - label: Android
+      - label: iOS
+      - label: Linux
+      - label: macOS
+      - label: Web
+      - label: Windows
+  - type: textarea
+    attributes:
+      label: Your question
+      description: |
+        Please describe your question as detailed as possible.
+
+        Please attach something to help us understand your question:
+         * code samples
+         * images
+         * videos
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Please specify which version of the plugin are you currently using.
+      placeholder: ex. 1.2.3
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+*Replace this paragraph with a short description of what issue this pull request (PR) solves and provide a description of the change.  Consider including before/after screenshots.*
+
+*List at least one fixed issue.*
+
+## Pre-launch Checklist
+
+- [ ] I made sure the project builds.
+- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
+- [ ] I updated `CHANGELOG.md` to add a description of the change.
+- [ ] I updated/added relevant documentation (doc comments with `///`).
+- [ ] I rebased onto `master`.
+- [ ] I ran `dart format .` and committed any changes.
+- [ ] I ran `flutter analyze` and fixed any errors.
+
+<!-- References -->
+[pub versioning philosophy]: https://dart.dev/tools/pub/versioning


### PR DESCRIPTION
This PR adds both PR- and issue templates to the repository. They are likely used rarely, but since we have added them already for other plugins (see for example https://github.com/Baseflow/flutter-google-api-availability/pull/47), this is low-hanging fruit.

### :memo: Links to relevant issues/docs

Closes #7.
