### PR TITLE
fix: use BottomAppBarThemeData for Flutter SDK compatibility

### DIFF
--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -40,7 +40,7 @@ class BaseflowPluginExample extends StatelessWidget {
           splashColor: themeMaterialColor.shade50,
           textTheme: ButtonTextTheme.primary,
         ),
-        bottomAppBarTheme: const BottomAppBarTheme(
+        bottomAppBarTheme: const BottomAppBarThemeData(
           color: Color.fromRGBO(57, 58, 71, 1),
         ),
         hintColor: themeMaterialColor.shade500,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  url_launcher: ^6.3.0
+  url_launcher: ^6.3.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This change replaces BottomAppBarTheme with BottomAppBarThemeData to match the Flutter SDK's ThemeData API.

This resolves the build error observed in CI when compiling with newer Flutter stable versions:
"The argument type 'BottomAppBarTheme' can't be assigned to the parameter type 'BottomAppBarThemeData?'."

Please bump package version after merge.

The failing CI job reference for context: ref 9c07d8a25d73d9263752b28cbbc491db6637423c.